### PR TITLE
Compilation errors and warnings removed

### DIFF
--- a/BLE.ino
+++ b/BLE.ino
@@ -179,7 +179,7 @@ bool connectToServer()
     // Read the value of the characteristic.
     if (pRemoteCharacteristic->canRead())
     {
-        std::string value = pRemoteCharacteristic->readValue();
+        String value = pRemoteCharacteristic->readValue(); // geändert wegen Fehlermeldung "conversion from 'String' to non-scalar type 'std::string' {aka 'std::__cxx11::basic_string<char>'} requested"
         commSerial.print("The characteristic value was: ");
         commSerial.println(value.c_str());
     }
@@ -188,6 +188,7 @@ bool connectToServer()
         pRemoteCharacteristic->registerForNotify(notifyCallback);
 
     BLE_client_connected = true;
+    return true;  // geändert wegen Warnmeldung Rückkehr ohne Wert non void
 }
 
 void sendCommand(uint8_t *data, uint32_t dataLen)

--- a/BMS_process_data.ino
+++ b/BMS_process_data.ino
@@ -55,8 +55,7 @@ bool processBasicInfo(packBasicInfoStruct *output, byte *data, unsigned int data
     output->Amps = ((int32_t)two_ints_into16(data[2], data[3])) * 10;   // Resolution 10 mA -> convert to miliamps
 
     output->Watts = output->Volts * output->Amps / 1000000; // W
-
-    output->CapacityRemainAh = ((uint16_t)two_ints_into16(data[4], data[5])) * 10;
+    output->CapacityRemainAh = ((uint32_t)two_ints_into16(data[4], data[5])) * 10;// auf32bit erweitert wege Überlauf
     output->CapacityRemainPercent = ((uint8_t)data[19]);
 
     output->CapacityRemainWh = (output->CapacityRemainAh * c_cellNominalVoltage) / 1000000 * packCellInfo.NumOfCells;

--- a/Smart-BMS-Bluetooth-ESP32.ino
+++ b/Smart-BMS-Bluetooth-ESP32.ino
@@ -1,37 +1,38 @@
 /**
-Program to read out and display 
-data from xiaoxiang Smart BMS 
-over Bluetooth Low Energy
-https://www.lithiumbatterypcb.com/
-Tested with original BLE module provided.
-Might work with generic BLE module when UUIDs are modified
+  Program to read out and display
+  data from xiaoxiang Smart BMS
+  over Bluetooth Low Energy
+  https://www.lithiumbatterypcb.com/
+  Tested with original BLE module provided.
+  Might work with generic BLE module when UUIDs are modified
 
-Needs ESP32 and graphic display.
-Tested on TTGO TS https://github.com/LilyGO/TTGO-TS
+  Needs ESP32 and graphic display.
+  Tested on TTGO TS https://github.com/LilyGO/TTGO-TS
 
-(c) Miroslav Kolinsky 2019
-https://www.kolins.cz
+  (c) Miroslav Kolinsky 2019
+  https://www.kolins.cz
 
-thanks to Petr Jenik for big parts of code
-thanks to Milan Petrzilka
+  thanks to Petr Jenik for big parts of code
+  thanks to Milan Petrzilka
 
-known bugs:
--if BLE server is not available during startup, program hangs
--reconnection sort of works, sometimes ESP reboots
+  known bugs:
+  -if BLE server is not available during startup, program hangs
+  -reconnection sort of works, sometimes ESP reboots
 */
 
 //#define TRACE commSerial.println(__FUNCTION__)
 #define TRACE
-//#define SIMULATION
 #include <Arduino.h>
 #include "BLEDevice.h"
-//#include "BLEScan.h"  //why this is commented?
+#include "BLEScan.h"  //why this is commented?
 #include "mydatatypes.h"
 #include <SPI.h>
-#include <TFT_eSPI.h>
-//#include <NeoPixelBrightnessBus.h>
-//#include <U8g2lib.h>
+#include "Adafruit_GFX.h"
+#include "Adafruit_ILI9341.h"
+#include <XPT2046_Touchscreen.h>
+#include <Fonts/FreeSansBold9pt7b.h>
 #include <Wire.h>
+#include "settings.h"
 
 // #include <WiFi.h>
 // #include <WiFiClient.h>
@@ -49,41 +50,65 @@ static boolean doConnect = false;
 static boolean BLE_client_connected = false;
 static boolean doScan = false;
 
-packBasicInfoStruct packBasicInfo; //here shall be the latest data got from BMS
-packEepromStruct packEeprom;	   //here shall be the latest data got from BMS
-packCellInfoStruct packCellInfo;   //here shall be the latest data got from BMS
+packBasicInfoStruct packBasicInfo;  //here shall be the latest data got from BMS
+packEepromStruct packEeprom;	      //here shall be the latest data got from BMS
+packCellInfoStruct packCellInfo;    //here shall be the latest data got from BMS
 
 const byte cBasicInfo3 = 3; //type of packet 3= basic info
 const byte cCellInfo4 = 4;  //type of packet 4= individual cell info
 
 unsigned long previousMillis = 0;
-const long interval = 2000;
+unsigned long previousMillisl = 0;
+const long myinterval = 5000;
+const long interval = 4000;
 
 bool toggle = false;
 bool newPacketReceived = false;
-
+int i = 0;
 void setup()
 {
 
-	commSerial.begin(115200, SERIAL_8N1, 3, 1);
-	bmsSerial.begin(9600, SERIAL_8N1, 21, 22);
-	commSerial.println("Starting ebike dashboard application...");
-	//	stripStartup();
-	//	oled_startup();
-	lcdStartup();
-	// newtworkStartup();
-	bleStartup();
+  commSerial.begin(115200, SERIAL_8N1, 3, 1);
+  bmsSerial.begin(9600, SERIAL_8N1, 21, 22);
+  commSerial.println("Starting BMS dashboard application...");
+  //	stripStartup();
+  //	oled_startup();
+  lcdStartup();
+  // newtworkStartup();
+  commSerial.println("LCD fertig...");
+
+  bleStartup();
+  lcdclear();
+  showInfoLcd();
+  lcdwarte();
+//  linearMeter(99, 10, 310, 5, 10, 1, 30, 5);
+//  for (int wi = 0; wi <= 100; wi = wi + 5) {
+//    kreis(wi,120, 90,80,80);
+//   delay(500);
+//  }
 }
 //---------------------main loop------------------
 void loop()
 {
-	bleRequestData();
-	//server.handleClient();
-	if (newPacketReceived == true)
-	{
-		showInfoLcd;
-		printBasicInfo();
-		printCellInfo();
-	}
+  //server.handleClient();
+  bleRequestData();
+
+/*
+  if (newPacketReceived == true)
+  {
+    showInfoLcd();
+    printBasicInfo();
+    printCellInfo();
+    commSerial.println("-");
+
+  }
+  commSerial.print(".");
+  i++;
+  if (i > 60) {
+    i = 0;
+    commSerial.println();
+  }
+  */
+  delay(1000);
 }
 //---------------------/ main loop------------------

--- a/mydatatypes.h
+++ b/mydatatypes.h
@@ -21,7 +21,7 @@ typedef struct
 	uint16_t Volts; // unit 1mV
 	int32_t Amps;   // unit 1mA
 	int32_t Watts;   // unit 1W
-	uint16_t CapacityRemainAh;
+	uint32_t CapacityRemainAh;  
 	uint8_t CapacityRemainPercent; //unit 1%
 	uint32_t CapacityRemainWh; 	//unit Wh
 	uint16_t Temp1;				   //unit 0.1C


### PR DESCRIPTION
Unfortunately, the program could no longer be translated.
Error message "conversion from 'String' to non-scalar type 'std::string' {aka 'std::__cxx11::basic_string<char>'} requested"
Then there was a warning message because the function bool connectToServer() did not return a return value for the function if everything is OK.
Since the variable CapacityRemainAh at 210 AH gave an overflow error value increased to uint32_t.

Leider ließ sich das Programm nicht mehr übersetzen.
Fehlermeldung "conversion from 'String' to non-scalar type 'std::string' {aka 'std::__cxx11::basic_string<char>'} requested"
Dann gab es eine Warnmeldung weil die Funktion bool connectToServer() keinen Rückgabewert für die Funktion zurückgab wenn alles in Ordnung ist.
Da die Variable CapacityRemainAh bei 210 AH einen Überlauffehler ausgab Wert auf uint32_t erhöht.
